### PR TITLE
Bug fix for Controls with no associated Component

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -1899,20 +1899,23 @@ def project_control_editor(request, system_id, catalog_key, cl_id, statement_id=
             return render(request, 'controls/detail.html', {'catalog': catalog, 'control': {}})
 
         statements = get_statements_by_component(system, cl_id, catalog_key, statement_id)
-        narrative = get_narrative(statements, statement_id)
-        narrative['title'] = narrative.get('producer_element_name')
-        if narrative.get('next'):
-            save = f'Save & next'
-            url = reverse('control_editor_statement',
-                args=[system.id, catalog_key, cl_id, narrative.get('next')])
+        if statements:
+            narrative = get_narrative(statements, statement_id)
+            narrative['title'] = narrative.get('producer_element_name')
+            if narrative.get('next'):
+                save = f'Save & next'
+                url = reverse('control_editor_statement',
+                    args=[system.id, catalog_key, cl_id, narrative.get('next')])
+            else:
+                save = f'Save'
+                url = reverse('control_editor_statement',
+                    args=[system.id, catalog_key, cl_id, narrative.get('sid')])
+            narrative['save'] = {
+                'text': save,
+                'url': url,
+            }
         else:
-            save = f'Save'
-            url = reverse('control_editor_statement',
-                args=[system.id, catalog_key, cl_id, narrative.get('sid')])
-        narrative['save'] = {
-            'text': save,
-            'url': url,
-        }
+            narrative = {}
 
         cat = get_catalog_data_by_control(catalog_key, cl_id)
         nav = project_navigation(request, project)


### PR DESCRIPTION
QA

- Create a Project without any associated Components
    - Click the + and choose Start a new Project
    - Go to the project page (/projects)
    -  You should see a new Project with a name like _CMS AWS # (None)_
- Under that Project click *View Controls*
- Click on any Control, for instance AC-1
- You should not get an error, but instead should see _There are no Components that address this Control._ for the *Control Narrative*