### PR TITLE
[ISPGBSS-634] BUG: Unhelpful error message when importing appsource with duplicate name

### DIFF
--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -21,7 +21,7 @@ from discussion.validators import validate_file_extension
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from django.http import (Http404, HttpResponse, HttpResponseForbidden,
                          HttpResponseNotAllowed, HttpResponseRedirect,
                          JsonResponse)
@@ -1453,6 +1453,9 @@ def authoring_import_appsource(request):
             return JsonResponse({ "status": "ok", "redirect": "/store" })
         except ValueError:
             messages.add_message(request, messages.ERROR, f'There was a failure processing {ValueError}. Please confirm that all included files are valid and try again.')
+            return JsonResponse({ "status": "ok", "redirect": "/store" })
+        except IntegrityError:
+            messages.add_message(request, messages.ERROR, f'There was a problem when trying to upload {appsource_zipfile}.  You are likely attempting to import a file that has already been imported.')
             return JsonResponse({ "status": "ok", "redirect": "/store" })
     else:
         messages.add_message(request, messages.ERROR, f'The AppSource file is required.')

--- a/siteapp/static/js/authoring_tool.js
+++ b/siteapp/static/js/authoring_tool.js
@@ -321,7 +321,6 @@ function authoring_tool_import_appsource_form(argument) {
 function authoring_tool_import_appsource() {
   // Use FormData to serialize form object including uploaded file
   var data = new FormData($('#import_appsource_authoring_tool form')[0]);
-  console.log("data is: "+JSON.stringify(data));
   ajax_with_indicator({
       url: "/tasks/_authoring_tool/import-appsource",
       method: "POST",

--- a/siteapp/static/vendor/bootstrap-helpers.js
+++ b/siteapp/static/vendor/bootstrap-helpers.js
@@ -179,15 +179,8 @@ function ajax_with_indicator(options) {
     if (options.complete)
       options.complete();
 
-    if (!old_error && jqxhr.status == 500 && /^text\/html/.test(jqxhr.getResponseHeader("content-type")) && /^(<!DOCTYPE[\w\W]*>)?\s*<html/.test(jqxhr.responseText)) {
-      // We might get back HTML in a 500 error. Flask does this. Show the
-      // HTML, in an iframe.
-      show_modal_error("Error", '<iframe style="width: 100%; height: 60vh;"></iframe>')
-      var ifrm = $('#global_modal').find('iframe')[0];
-      ifrm = (ifrm.contentWindow) ? ifrm.contentWindow : (ifrm.contentDocument.document) ? ifrm.contentDocument.document : ifrm.contentDocument;
-      ifrm.document.open();
-      ifrm.document.write(jqxhr.responseText);
-      ifrm.document.close();
+    if (!old_error && jqxhr.status == 500 && /^text\/html/.test(jqxhr.getResponseHeader("content-type")) && /^(<!DOCTYPE[\w\W]*>)?\s*<html/.test(jqxhr.responseText)) {      
+      show_modal_error(jqxhr.statusText, jqxhr.responseJSON.message )
     } else if (!old_error) {
       show_modal_error("Error", "Something went wrong, sorry.")
     } else {


### PR DESCRIPTION
Description:  
1. The originally error handling around uploading an AppSource zip simply rendered an iFrame within a modal and displayed whatever came back from Django regardless of the error.  When a user tried to upload an AppSource zip that was already uploaded, the iFrame failed to render properly and displayed markup script in a modal.
2. There is also code to handle errors from Flask....which is confusing

Changes
1. Removed an errant `console.log`
2. We are now using built in Django error handling to catch error types specifically instead of displaying gibberish markup.  

Risks
1. `bootstrap_helpers.js` is completely untested.  I believe that this file can be simplified drastically but I'm afraid to be too heavy-handed in it's current state.  As far as I can tell, we are not testing JS at all currently.  We probably need to sync up to plan a path forward here.  We may also decided to just remove all JS modal error handling in favor of Django error handling. 
