### PR TITLE
bug/fix navbar wrapping onto multiple lines

### DIFF
--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -15,7 +15,7 @@
         </ul>
       </div>
 
-      <div id="header-right" class="grid-col-3">
+      <div id="header-right">
         <ul class="nav navbar-nav navbar-right">
           {% if request.user.is_authenticated %}
           <!-- Create new projects, portfolios -->


### PR DESCRIPTION
https://jiraent.cms.gov/browse/ISPGBSS-788

### Changes
- stop the right-side navbar from wrapping content onto multiple lines when there is enough room by removing the grid col restriction

### Testing
- Load the website and log in. Then ensure all the navbar content remains on one line when on any page of the site. (_Note: if the screen width is made smaller, the content will no longer fit on one line and will be forced to wrap- we can determine alternatives such as using a menu button when this happens in the future_) 