### PR TITLE
update new project urls; linting updates

### DIFF
--- a/project/models.py
+++ b/project/models.py
@@ -5,39 +5,77 @@ from controls.oscal import CatalogData
 from siteapp.models import User
 
 
-# TODO "PackageRename" rename class to Project once the old Project class in /siteapp/models has been removed
+# TODO "PackageRename" rename class to Project
+# once the old Project class in /siteapp/models has been removed
 class Package(models.Model):
-    title = models.CharField(max_length=100, help_text="Name of the project", unique=False)
-    acronym = models.CharField(max_length=20, help_text="Acronym for the name of the project", unique=False)
-    catalog = models.ForeignKey(CatalogData, related_name='used_by_projects', on_delete=models.CASCADE, blank=True, null=True, help_text="Catalog of controls that the project uses")
-    components = models.ManyToManyField(Element, limit_choices_to={'element_type': 'system_element'}, related_name='used_by_projects', default=None, blank=True, help_text="Components that exist in the project")
-    creator = models.ForeignKey(User, on_delete=models.PROTECT, default=None, related_name='projects_created', help_text="User id of the project creator")
+    title = models.CharField(
+        max_length=100, help_text="Name of the project", unique=False
+    )
+    acronym = models.CharField(
+        max_length=20, help_text="Acronym for the name of the project", unique=False
+    )
+    catalog = models.ForeignKey(
+        CatalogData,
+        related_name="used_by_projects",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        help_text="Catalog of controls that the project uses",
+    )
+    components = models.ManyToManyField(
+        Element,
+        limit_choices_to={"element_type": "system_element"},
+        related_name="used_by_projects",
+        default=None,
+        blank=True,
+        help_text="Components that exist in the project",
+    )
+    creator = models.ForeignKey(
+        User,
+        on_delete=models.PROTECT,
+        default=None,
+        related_name="projects_created",
+        help_text="User id of the project creator",
+    )
     IMPACT_LEVEL_CHOICES = [
-        ('low', 'Low'),
-        ('moderate', 'Moderate'),
-        ('high', 'High'),
-        ('unknown', 'Don\'t Know'),
+        ("low", "Low"),
+        ("moderate", "Moderate"),
+        ("high", "High"),
+        ("unknown", "Don't Know"),
     ]
-    impact_level = models.CharField(choices=IMPACT_LEVEL_CHOICES, max_length=20, default=None, null=True, help_text='FISMA impact level of the project')
+    impact_level = models.CharField(
+        choices=IMPACT_LEVEL_CHOICES,
+        max_length=20,
+        default=None,
+        null=True,
+        help_text="FISMA impact level of the project",
+    )
     LOCATION_CHOICES = [
-        ('cms_aws', 'CMS AWS Commercial East-West'),
-        ('govcloud', 'CMS AWS GovCloud'),
-        ('azure', 'Microsoft Azure'),
-        ('other', 'Other')
+        ("cms_aws", "CMS AWS Commercial East-West"),
+        ("govcloud", "CMS AWS GovCloud"),
+        ("azure", "Microsoft Azure"),
+        ("other", "Other"),
     ]
-    location = models.CharField(choices=LOCATION_CHOICES, max_length=100, default=None, null=True, help_text='Where the project is located')
+    location = models.CharField(
+        choices=LOCATION_CHOICES,
+        max_length=100,
+        default=None,
+        null=True,
+        help_text="Where the project is located",
+    )
     created = models.DateTimeField(auto_now_add=True, db_index=True)
     updated = models.DateTimeField(auto_now=True, db_index=True, null=True)
 
-    # Additional permissions to manage members. (Add, change, delete, and view permissions are automatically created)
+    # Additional permissions to manage members.
+    # (Add, change, delete, and view permissions are automatically created)
     class Meta:
         permissions = [
-            ('can_add_members', 'Can add members'),
-            ('can_delete_members', 'Can delete members')
+            ("can_add_members", "Can add members"),
+            ("can_delete_members", "Can delete members"),
         ]
 
     def __str__(self):
         return "%s id=%d" % (self.title, self.id)
 
     def get_absolute_url(self):
-        return f"/project/{self.id}"
+        return f"/packages/{self.id}"

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -9,85 +9,91 @@ class PackageModelTest(TestCase):
     def setUpTestData(cls):
         cls.test_user = User.objects.create()
 
-        Package.objects.create(title='Pretty Ordinary Project', acronym='POP', impact_level='unknown', location='other', creator=User.objects.get(id=1))
+        Package.objects.create(
+            title="Pretty Ordinary Project",
+            acronym="POP",
+            impact_level="unknown",
+            location="other",
+            creator=User.objects.get(id=1),
+        )
 
     # Tests for field labels
     def test_title_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('title').verbose_name
-        self.assertEqual(field_label, 'title')
+        field_label = project._meta.get_field("title").verbose_name
+        self.assertEqual(field_label, "title")
 
     def test_acronym_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('acronym').verbose_name
-        self.assertEqual(field_label, 'acronym')
+        field_label = project._meta.get_field("acronym").verbose_name
+        self.assertEqual(field_label, "acronym")
 
     def test_impact_level_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('impact_level').verbose_name
-        self.assertEqual(field_label, 'impact level')
+        field_label = project._meta.get_field("impact_level").verbose_name
+        self.assertEqual(field_label, "impact level")
 
     def test_location_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('location').verbose_name
-        self.assertEqual(field_label, 'location')
+        field_label = project._meta.get_field("location").verbose_name
+        self.assertEqual(field_label, "location")
 
     def test_creator_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('creator_id').verbose_name
-        self.assertEqual(field_label, 'creator')
+        field_label = project._meta.get_field("creator_id").verbose_name
+        self.assertEqual(field_label, "creator")
 
     def test_catalog_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('catalog_id').verbose_name
-        self.assertEqual(field_label, 'catalog')
+        field_label = project._meta.get_field("catalog_id").verbose_name
+        self.assertEqual(field_label, "catalog")
 
     def test_components_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('components').verbose_name
-        self.assertEqual(field_label, 'components')
+        field_label = project._meta.get_field("components").verbose_name
+        self.assertEqual(field_label, "components")
 
     def test_created_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('created').verbose_name
-        self.assertEqual(field_label, 'created')
+        field_label = project._meta.get_field("created").verbose_name
+        self.assertEqual(field_label, "created")
 
     def test_updated_label(self):
         project = Package.objects.get(id=1)
-        field_label = project._meta.get_field('updated').verbose_name
-        self.assertEqual(field_label, 'updated')
+        field_label = project._meta.get_field("updated").verbose_name
+        self.assertEqual(field_label, "updated")
 
     # Tests for max length
     def test_title_max_length(self):
         project = Package.objects.get(id=1)
-        max_length = project._meta.get_field('title').max_length
+        max_length = project._meta.get_field("title").max_length
         self.assertEqual(max_length, 100)
 
     def test_acronym_max_length(self):
         project = Package.objects.get(id=1)
-        max_length = project._meta.get_field('acronym').max_length
+        max_length = project._meta.get_field("acronym").max_length
         self.assertEqual(max_length, 20)
 
     def test_impact_level_max_length(self):
         project = Package.objects.get(id=1)
-        max_length = project._meta.get_field('impact_level').max_length
+        max_length = project._meta.get_field("impact_level").max_length
         self.assertEqual(max_length, 20)
 
     def test_location_max_length(self):
         project = Package.objects.get(id=1)
-        max_length = project._meta.get_field('location').max_length
+        max_length = project._meta.get_field("location").max_length
         self.assertEqual(max_length, 100)
 
     # Tests for model functions
     def test_object_str_returns_project_title_and_id(self):
         project = Package.objects.get(id=1)
-        expected_object_name = f'{project.title} id={project.id}'
+        expected_object_name = f"{project.title} id={project.id}"
 
         self.assertEqual(str(project), expected_object_name)
 
     def test_get_absolute_url(self):
-        test_id=1
-        expected_url = f'/project/{test_id}'
+        test_id = 1
+        expected_url = f"/packages/{test_id}"
 
         project = Package.objects.get(id=test_id)
         self.assertEqual(project.get_absolute_url(), expected_url)

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -8,25 +8,37 @@ from siteapp.models import User
 class ProjectViewTest(TestCase):
     def setUp(self):
         # Create a user
-        test_user = User.objects.create_user(username='testuser', password='password', is_superuser=True, is_staff=True, is_active=True)
+        test_user = User.objects.create_user(
+            username="testuser",
+            password="password",
+            is_superuser=True,
+            is_staff=True,
+            is_active=True,
+        )
 
         # Create a project
-        Package.objects.create(title="Rapid Rabbit", acronym="RR", location="other", impact_level="low", creator=test_user)
+        Package.objects.create(
+            title="Rapid Rabbit",
+            acronym="RR",
+            location="other",
+            impact_level="low",
+            creator=test_user,
+        )
 
     def test_redirect_if_not_logged_in(self):
         projects = Package.objects.all()
         test_project_id = projects[0].id
-        test_project_url = f'/project/{test_project_id}/'
+        test_project_url = f"/packages/{test_project_id}/"
 
         response = self.client.get(test_project_url)
-        self.assertRedirects(response, f'/accounts/login/?next={test_project_url}')
+        self.assertRedirects(response, f"/accounts/login/?next={test_project_url}")
 
     def test_view_url_exists_at_desired_location(self):
         projects = Package.objects.all()
         test_project_id = projects[0].id
-        test_project_url = f'/project/{test_project_id}/'
+        test_project_url = f"/packages/{test_project_id}/"
 
-        logged_in = self.client.login(username='testuser', password='password')
+        logged_in = self.client.login(username="testuser", password="password")
         self.assertTrue(logged_in)
 
         response = self.client.get(test_project_url)
@@ -36,122 +48,143 @@ class ProjectViewTest(TestCase):
         projects = Package.objects.all()
         test_project_id = projects[0].id
 
-        self.client.login(username='testuser', password='password')
+        self.client.login(username="testuser", password="password")
 
-        response = self.client.get(reverse('project_homepage', kwargs={'project_id': test_project_id}))
+        response = self.client.get(
+            reverse("project_homepage", kwargs={"project_id": test_project_id})
+        )
         self.assertEqual(response.status_code, 200)
 
     def test_uses_correct_template(self):
         projects = Package.objects.all()
         test_project_id = projects[0].id
 
-        self.client.login(username='testuser', password='password')
+        self.client.login(username="testuser", password="password")
 
-        response = self.client.get(reverse('project_homepage', kwargs={'project_id': test_project_id}))
+        response = self.client.get(
+            reverse("project_homepage", kwargs={"project_id": test_project_id})
+        )
         self.assertEqual(response.status_code, 200)
 
         # Check we used correct template
-        self.assertTemplateUsed(response, 'project/project-home.html')
+        self.assertTemplateUsed(response, "project/project-home.html")
+
 
 class CreateProjectViewTest(TestCase):
     def setUp(self):
         # Create a user
-        User.objects.create_user(username='testuser', password='password', is_superuser=True, is_staff=True, is_active=True)
+        User.objects.create_user(
+            username="testuser",
+            password="password",
+            is_superuser=True,
+            is_staff=True,
+            is_active=True,
+        )
 
     def test_redirect_if_not_logged_in(self):
-        attempted_url = '/project/create'
+        attempted_url = "/packages/create"
         response = self.client.get(attempted_url)
-        self.assertRedirects(response, f'/accounts/login/?next={attempted_url}')
+        self.assertRedirects(response, f"/accounts/login/?next={attempted_url}")
 
     def test_view_url_exists_at_desired_location(self):
-        logged_in = self.client.login(username='testuser', password='password')
+        logged_in = self.client.login(username="testuser", password="password")
         self.assertTrue(logged_in)
 
-        response = self.client.get('/project/create')
+        response = self.client.get("/packages/create")
         self.assertEqual(response.status_code, 200)
 
     def test_view_url_accessible_by_name(self):
-        self.client.login(username='testuser', password='password')
-        response = self.client.get(reverse('create_project'))
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(reverse("create_project"))
         self.assertEqual(response.status_code, 200)
 
     def test_uses_correct_template(self):
-        self.client.login(username='testuser', password='password')
-        response = self.client.get(reverse('create_project'))
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(reverse("create_project"))
         self.assertEqual(response.status_code, 200)
 
         # Check we used correct template
-        self.assertTemplateUsed(response, 'project/project-create.html')
+        self.assertTemplateUsed(response, "project/project-create.html")
 
     def test_can_submit_with_baseline_required_data_fields(self):
         required_data = {
             "title": "Rapid Rabbit",
             "acronym": "RR",
             "location": "other",
-            "impact_level": "low"
+            "impact_level": "low",
         }
         expected_count_of_projects_in_database = 1
 
-        self.client.login(username='testuser', password='password')
-        self.client.post('/project/create', required_data)
-        self.assertEqual(Package.objects.count(), expected_count_of_projects_in_database)
+        self.client.login(username="testuser", password="password")
+        self.client.post("/packages/create", required_data)
+        self.assertEqual(
+            Package.objects.count(), expected_count_of_projects_in_database
+        )
 
     def test_CANNOT_submit_with_missing_title_field(self):
         data_without_title = {
             "acronym": "RR",
             "location": "other",
-            "impact_level": "low"
+            "impact_level": "low",
         }
         expected_count_of_projects_in_database = 0
 
-        self.client.login(username='testuser', password='password')
-        self.client.post('/project/create', data_without_title)
-        self.assertEqual(Package.objects.count(), expected_count_of_projects_in_database)
+        self.client.login(username="testuser", password="password")
+        self.client.post("/packages/create", data_without_title)
+        self.assertEqual(
+            Package.objects.count(), expected_count_of_projects_in_database
+        )
 
     def test_CANNOT_submit_with_missing_acronym_field(self):
         data_without_acronym = {
             "title": "Rapid Rabbit",
             "location": "other",
-            "impact_level": "low"
+            "impact_level": "low",
         }
         expected_count_of_projects_in_database = 0
 
-        self.client.login(username='testuser', password='password')
-        self.client.post('/project/create', data_without_acronym)
-        self.assertEqual(Package.objects.count(), expected_count_of_projects_in_database)
+        self.client.login(username="testuser", password="password")
+        self.client.post("/packages/create", data_without_acronym)
+        self.assertEqual(
+            Package.objects.count(), expected_count_of_projects_in_database
+        )
 
     def test_CANNOT_submit_with_missing_location_field(self):
         data_without_location = {
             "title": "Rapid Rabbit",
             "acronym": "RR",
-            "impact_level": "low"
+            "impact_level": "low",
         }
         expected_count_of_projects_in_database = 0
 
-        self.client.login(username='testuser', password='password')
-        self.client.post('/project/create', data_without_location)
-        self.assertEqual(Package.objects.count(), expected_count_of_projects_in_database)
+        self.client.login(username="testuser", password="password")
+        self.client.post("/packages/create", data_without_location)
+        self.assertEqual(
+            Package.objects.count(), expected_count_of_projects_in_database
+        )
 
     def test_CANNOT_submit_with_missing_impact_level_field(self):
         data_without_impact_level = {
             "title": "Rapid Rabbit",
             "acronym": "RR",
-            "location": "other"
+            "location": "other",
         }
         expected_count_of_projects_in_database = 0
 
-        self.client.login(username='testuser', password='password')
-        self.client.post('/project/create', data_without_impact_level)
-        self.assertEqual(Package.objects.count(), expected_count_of_projects_in_database)
+        self.client.login(username="testuser", password="password")
+        self.client.post("/packages/create", data_without_impact_level)
+        self.assertEqual(
+            Package.objects.count(), expected_count_of_projects_in_database
+        )
 
     def test_redirects_to_projects_page_on_success(self):
         required_data = {
             "title": "Rapid Rabbit",
             "acronym": "RR",
             "location": "other",
-            "impact_level": "low"
+            "impact_level": "low",
         }
 
-        self.client.login(username='testuser', password='password')
-        response = self.client.post('/project/create', required_data)
-        self.assertRedirects(response, reverse('projects'))
+        self.client.login(username="testuser", password="password")
+        response = self.client.post("/packages/create", required_data)
+        self.assertRedirects(response, reverse("projects"))

--- a/project/urls.py
+++ b/project/urls.py
@@ -3,15 +3,33 @@ from django.urls import path
 import project.views as views
 
 urlpatterns = [
-    path('create', views.create_project, name='create_project'),
-    path('<int:project_id>/', views.project, name='project_homepage'),
-    path('<int:project_id>/components/', views.project, name='project_components'),
-    path('<int:project_id>/component/<int:component_id>/', views.project_component_detail, name='project_component_detail'),
-    path('<int:project_id>/components/<int:component_id>/statement/<int:statement_id>/', views.project, name='project_component_detail_by_control'),
-    path('<int:project_id>/controls/', views.project, name='project_controls'),
-    path('<int:project_id>/control/<int:control_id>/', views.project, name='project_control_detail'),
-    path('<int:project_id>/control/<int:control_id>/component/<int:component_id>/', views.project, name='project_control_detail_by_component'),
-    path('<int:project_id>/download/', views.project, name='project_export'),
-    path('<int:project_id>/settings/', views.project, name='project_settings'),
-    path('<int:project_id>/settings/edit/', views.project, name='project_settings_edit'),
+    path("create", views.create_project, name="create_project"),
+    path("<int:project_id>/", views.project, name="project_homepage"),
+    path("<int:project_id>/components/", views.project, name="project_components"),
+    path(
+        "<int:project_id>/components/<int:component_id>/",
+        views.project_component_detail,
+        name="project_component_detail",
+    ),
+    path(
+        "<int:project_id>/components/<int:component_id>/statements/<int:statement_id>/",
+        views.project,
+        name="project_component_detail_by_control",
+    ),
+    path("<int:project_id>/controls/", views.project, name="project_controls"),
+    path(
+        "<int:project_id>/controls/<int:control_id>/",
+        views.project,
+        name="project_control_detail",
+    ),
+    path(
+        "<int:project_id>/controls/<int:control_id>/components/<int:component_id>/",
+        views.project,
+        name="project_control_detail_by_component",
+    ),
+    path("<int:project_id>/download/", views.project, name="project_export"),
+    path("<int:project_id>/settings/", views.project, name="project_settings"),
+    path(
+        "<int:project_id>/settings/edit/", views.project, name="project_settings_edit"
+    ),
 ]

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -86,8 +86,8 @@ urlpatterns = [
     url(r'^projects/(\d+)/(?:[\w\-]+)(/api)$', views.project_api), # must be last because regex matches some previous URLs
     path('projects/<int:project_id>/<slug:title>/downloads', views.project_downloads, name='project_downloads'),
 
-    # individual project
-    path('project/', include("project.urls")),
+    # individual projects
+    path('packages/', include("project.urls")),
 
     # portfolios
     url(r'^portfolios$', views.portfolio_list, name="list_portfolios"),


### PR DESCRIPTION
### Changes
- updated url schema to follow best practices (reference: https://restfulapi.net/resource-naming/)
- linting updates

### Testing
- run the automated tests
    - Bash into the container `docker exec -it govready-q-dev bash`
    - Run `python3 manage.py test`
- ensure the new urls are working to load "/packages/create"
- you can visit the project homepage for the project you just created using the id found in the database (Example: [http://localhost:8000/packages/{id}/](http://localhost:8000/packages/%7Bid%7D/))

### Dev notes
- renamed project in urls to packages so it doesn't interfere with existing urls using projects. We will want to update this later when switching over to the new project model.