### PR TITLE
Bug: Component library error

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -1684,7 +1684,7 @@ def component_library_component(request, element_id, statement_id=None):
     for s in systems:
         root_ids.append(s.root_element_id)
         cat_id = ElementControl.objects.filter(element_id=s.root_element_id).first()
-        if cat_id and cat_id.oscal_catalog_key != catalog_key:
+        if not cat_id or cat_id.oscal_catalog_key != catalog_key:
             options.pop(s.id)
     existing_list = (
         Statement.objects.filter(consumer_element_id__in=root_ids)

--- a/controls/views.py
+++ b/controls/views.py
@@ -1684,7 +1684,7 @@ def component_library_component(request, element_id, statement_id=None):
     for s in systems:
         root_ids.append(s.root_element_id)
         cat_id = ElementControl.objects.filter(element_id=s.root_element_id).first()
-        if cat_id.oscal_catalog_key != catalog_key:
+        if cat_id and cat_id.oscal_catalog_key != catalog_key:
             options.pop(s.id)
     existing_list = (
         Statement.objects.filter(consumer_element_id__in=root_ids)


### PR DESCRIPTION
[Jira: ISPGBSS-853](https://jiraent.cms.gov/browse/ISPGBSS-853)

If a Project doesn't have an associated Impact Level, viewing a Component in the Component Library throws an error.

This PR adds a conditional check to ensure that there is an association with at least one _ElementControl_ (baseline control).

QA:
In your local instance:

- Click the **+** in the header and choose _Start a new project_
- Don't continue the process of creating a project, but rather, from the header choose **Component Library**
- Click on the _Ilias_ component
- The page should not throw an error
- Your Project should not appear in the dropdown