### PR TITLE
Fix too many redirects error

### DIFF
--- a/siteapp/oidc.py
+++ b/siteapp/oidc.py
@@ -20,6 +20,7 @@ class OIDCProfile:
         self.claims_map = config["claims_map"]
         self.roles_map = config["roles_map"]
         self.scopes = "openid email profile"
+        self.hasJobcode = False
 
     def get_endpoint(self, name: str) -> str:
         default_endpoint = self.defaults.get(name, None)
@@ -48,6 +49,7 @@ class OIDCProfile:
             "username": claims[self.get_claim_name("username")],
             "is_staff": self.is_admin(claims.get(self.get_claim_name("groups"), {})),
         }
+        self.hasJobcode = self.hasProperJobcode(claims)
         return attrs
 
     def is_admin(self, groups):
@@ -63,12 +65,15 @@ class OIDCProfile:
             return False
 
     """ check if both admin and user job codes are not present in claims map """
-    def hasProperJobcode(self):
+    def hasProperJobcode(self, claims):
         if self.is_admin(claims.get(self.get_claim_name("groups"), {})):
             return True
         if self.is_user(claims.get(self.get_claim_name("groups"), {})):
             return True
         return False
+
+    def hasJobcode(self):
+        return self.hasJobcode()
 
 class OKTAOIDCProfile(OIDCProfile):
     defaults = {

--- a/siteapp/oidc.py
+++ b/siteapp/oidc.py
@@ -56,9 +56,21 @@ class OIDCProfile:
         else:
             return False
 
+    def is_user(self, groups):
+        if self.get_role_name("user") in groups:
+            return True
+        else:
+            return False
+
+    """ check if both admin and user job codes are not present in claims map """
+    def hasProperJobcode(self):
+        if is_admin(claims.get(self.get_claim_name("groups"), {})):
+            return True
+        if is_user(claims.get(self.get_claim_name("groups"), {})):
+            return True
+        return False
 
 class OKTAOIDCProfile(OIDCProfile):
-
     defaults = {
         "oidc_op_jwks_endpoint": "/v1/keys",
         "oidc_op_authorization_endpoint": "/v1/authorize",
@@ -68,7 +80,6 @@ class OKTAOIDCProfile(OIDCProfile):
 
 
 class AUTH0OIDCProfile(OIDCProfile):
-
     defaults = {
         "oidc_op_jwks_endpoint": "/.well-known/jwks.json",
         "oidc_op_authorization_endpoint": "/authorize",

--- a/siteapp/oidc.py
+++ b/siteapp/oidc.py
@@ -64,9 +64,9 @@ class OIDCProfile:
 
     """ check if both admin and user job codes are not present in claims map """
     def hasProperJobcode(self):
-        if is_admin(claims.get(self.get_claim_name("groups"), {})):
+        if self.is_admin(claims.get(self.get_claim_name("groups"), {})):
             return True
-        if is_user(claims.get(self.get_claim_name("groups"), {})):
+        if self.is_user(claims.get(self.get_claim_name("groups"), {})):
             return True
         return False
 

--- a/siteapp/oidc.py
+++ b/siteapp/oidc.py
@@ -49,7 +49,7 @@ class OIDCProfile:
             "username": claims[self.get_claim_name("username")],
             "is_staff": self.is_admin(claims.get(self.get_claim_name("groups"), {})),
         }
-        self.hasJobcode = self.hasProperJobcode(claims)
+        self.hasJobcode = self.processJobcodes(claims)
         return attrs
 
     def is_admin(self, groups):
@@ -65,15 +65,15 @@ class OIDCProfile:
             return False
 
     """ check if both admin and user job codes are not present in claims map """
-    def hasProperJobcode(self, claims):
+    def processJobcodes(self, claims):
         if self.is_admin(claims.get(self.get_claim_name("groups"), {})):
             return True
         if self.is_user(claims.get(self.get_claim_name("groups"), {})):
             return True
         return False
 
-    def hasJobcode(self):
-        return self.hasJobcode()
+    def hasProperJobcode(self):
+        return self.hasJobcode
 
 class OKTAOIDCProfile(OIDCProfile):
     defaults = {

--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -37,7 +37,7 @@ LOGIN_REDIRECT_URL = f"{BASE_URL}/"
 if OIDC_CONFIG:
     logger.info("OpenID Connect configuration found and enabled")
     profile = get_profile(OIDC_CONFIG)
-    hasProperJobcodes = profile.hasProperJobcode()
+    hasProperJobcodes = profile.hasJobcode()
     if not hasProperJobcodes:
         LOGIN_REDIRECT_URL = f"{BASE_URL}/redirect-error"
     OIDC_PROFILE = profile

--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -37,7 +37,7 @@ LOGIN_REDIRECT_URL = f"{BASE_URL}/"
 if OIDC_CONFIG:
     logger.info("OpenID Connect configuration found and enabled")
     profile = get_profile(OIDC_CONFIG)
-    hasProperJobcodes = profile.hasJobcode()
+    hasProperJobcodes = profile.hasProperJobcode()
     if not hasProperJobcodes:
         LOGIN_REDIRECT_URL = f"{BASE_URL}/redirect-error"
     OIDC_PROFILE = profile

--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -37,6 +37,9 @@ LOGIN_REDIRECT_URL = f"{BASE_URL}/"
 if OIDC_CONFIG:
     logger.info("OpenID Connect configuration found and enabled")
     profile = get_profile(OIDC_CONFIG)
+    hasProperJobcodes = profile.hasProperJobcode()
+    if not hasProperJobcodes:
+        LOGIN_REDIRECT_URL = f"{BASE_URL}/redirect-error"
     OIDC_PROFILE = profile
     logger.debug("OIDC using profile %r", profile)
     LOGIN_ENABLED = False

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -141,6 +141,7 @@ if settings.OIDC_CONFIG:
     urlpatterns += [
         path('oidc/', include('mozilla_django_oidc.urls')),
         url(r'^accounts/logout/$', views.logged_out, name="logged_out"),
+        url(r'^redirect-error/$', views.redirect_error, name="redirect-error"),
         re_path(r'^accounts/login/$', RedirectView.as_view(url='/oidc/authenticate', permanent=False), name='login2')
     ]
 

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -141,7 +141,7 @@ if settings.OIDC_CONFIG:
     urlpatterns += [
         path('oidc/', include('mozilla_django_oidc.urls')),
         url(r'^accounts/logout/$', views.logged_out, name="logged_out"),
-        url(r'^redirect-error/$', views.redirect_error, name="redirect-error"),
+        path('redirect-error/', views.redirect_error, name="redirect-error"),
         re_path(r'^accounts/login/$', RedirectView.as_view(url='/oidc/authenticate', permanent=False), name='login2')
     ]
 

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -2502,9 +2502,7 @@ def redirect_error(request):
         event="redirect_error",
         user={"id": request.user.id, "username": request.user.username}
     )
-    output = "Invalid job code. Please add proper job codes to your EUA profile."
-    html = "<html><body><pre>{}</pre></body></html>".format(output)
-    return HttpResponse(html)
+    return render(request, "redirect-error.html", {})
 
 @login_required
 def list_tags(request):

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -85,7 +85,6 @@ def logged_out(request):
     logout(request)
     return render(request, "account/logged-out.html", {})
 
-
 def homepage(request):
     if request.user.is_authenticated:
         return HttpResponseRedirect("/projects")
@@ -2498,6 +2497,14 @@ def sso_logout(request):
     html = "<html><body><pre>{}</pre></body></html>".format(output)
     return HttpResponse(html)
 
+def redirect_error(request):
+    logger.info(
+        event="redirect_error",
+        user={"id": request.user.id, "username": request.user.username}
+    )
+    output = "Invalid job code. Please add proper job codes to your EUA profile."
+    html = "<html><body><pre>{}</pre></body></html>".format(output)
+    return HttpResponse(html)
 
 @login_required
 def list_tags(request):

--- a/templates/redirect-error.html
+++ b/templates/redirect-error.html
@@ -1,20 +1,11 @@
 {% block title %}
 Error
 {% endblock %}
-
-{% block breadcrumbs %}
-<li class="active">Invalid job code</li>
-{% endblock %}
-
-<!-- Remove contextbar from top of page -->
-{% block contextbar %}{% endblock %}
-
 {% block body %}
-
+<h1>Invalid job code</h1>
 <div style="margin-top: 30px">
   <div class="container">
     <p>Please add proper job codes to your EUA profile.</p>
   </div>
 </div>
-    
 {% endblock %}

--- a/templates/redirect-error.html
+++ b/templates/redirect-error.html
@@ -1,8 +1,5 @@
-{% extends "base.html" %}
-{% load q %}
-
 {% block title %}
-404
+Error
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/templates/redirect-error.html
+++ b/templates/redirect-error.html
@@ -2,10 +2,10 @@
 Error
 {% endblock %}
 {% block body %}
-<h1>Invalid job code</h1>
-<div style="margin-top: 30px">
-  <div class="container">
-    <p>Please add proper job codes to your EUA profile.</p>
-  </div>
-</div>
+    <h1>Invalid job code</h1>
+    <div style="margin-top: 30px">
+      <div class="container">
+        <p>Please add proper job codes to your EUA profile.</p>
+      </div>
+    </div>
 {% endblock %}

--- a/templates/redirect-error.html
+++ b/templates/redirect-error.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% load q %}
+
+{% block title %}
+404
+{% endblock %}
+
+{% block breadcrumbs %}
+<li class="active">Invalid job code</li>
+{% endblock %}
+
+<!-- Remove contextbar from top of page -->
+{% block contextbar %}{% endblock %}
+
+{% block body %}
+
+<div style="margin-top: 30px">
+  <div class="container">
+    <p>Please add proper job codes to your EUA profile.</p>
+  </div>
+</div>
+    
+{% endblock %}


### PR DESCRIPTION
Fix for "too many redirects error" message which was occurring due to IDM & Blueprint application continuously redirecting to each other when proper job codes are not present.