### PR TITLE
Basic Cypress flows and commands

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,10 @@
-{}
+{
+  "env": {
+    "baseUrl": "localhost:8000",
+    "loginUrl": "localhost:8000/login",
+    "dev_user": {
+      "name": "admin",
+      "password": "thVHc4uusAEB"
+    }
+  }
+}

--- a/cypress/integration/Basic Flows/component_library.spec.js
+++ b/cypress/integration/Basic Flows/component_library.spec.js
@@ -1,0 +1,38 @@
+/// <reference types="cypress" />
+
+context('Component Library', () => {
+  before(()=> {
+    cy.loginWithUI()
+
+    //make sure that there is a project to work with when only running this file
+    let projectTitle = "Componenet Library Test"
+    let projectAcronym = "CLT"
+
+    cy.visit(Cypress.env('baseUrl') + '/packages/create')
+
+    // filling out form
+    cy.get('#id_title').type(projectTitle)
+    cy.get('#id_acronym').type(projectAcronym)
+    cy.get('.usa-radio__label').contains('CMS AWS Commercial East-West').click()
+
+    cy.get('.usa-radio__label').contains('Low').click()
+    cy.get('#next-button').click()
+  })
+  
+  it('user can view component library page', () => {
+    cy.visit(Cypress.env('baseUrl') + '/controls/components')
+    cy.get('a').contains('Active Directory').click()
+
+    cy.get('.usa-accordion__button').contains('CMS Implementation Standard').click()
+    cy.get('#b-a1').should('be.visible')
+
+    cy.get('.usa-accordion__button').contains('Guidance').click()
+    cy.get('#b-a2').should('be.visible')
+
+    // always visibile on page load
+    cy.get('#b-a3').should('be.visible')
+
+    // left Controls nav is loaded
+    cy.get('h4').contains('Controls').should('be.visibile')
+  })
+})

--- a/cypress/integration/Basic Flows/component_library.spec.js
+++ b/cypress/integration/Basic Flows/component_library.spec.js
@@ -31,8 +31,5 @@ context('Component Library', () => {
 
     // always visibile on page load
     cy.get('#b-a3').should('be.visible')
-
-    // left Controls nav is loaded
-    cy.get('h4').contains('Controls').should('be.visibile')
   })
 })

--- a/cypress/integration/Basic Flows/nav-bar.spec.js
+++ b/cypress/integration/Basic Flows/nav-bar.spec.js
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+
+const { get } = require("lodash")
+
+context('Navigation', () => {
+    beforeEach(() => {
+        cy.loginWithUI()
+    })
+
+    it('properly renders the navigation', () => {
+        cy.get('.navbar').should('be.visible')
+        cy.get('.navbar').should('contain.text', 'Projects')
+        cy.get('.navbar').should('contain.text', 'Component Library')
+    })
+})

--- a/cypress/integration/Basic Flows/nav-bar.spec.js
+++ b/cypress/integration/Basic Flows/nav-bar.spec.js
@@ -1,7 +1,5 @@
 /// <reference types="cypress" />
 
-const { get } = require("lodash")
-
 context('Navigation', () => {
     beforeEach(() => {
         cy.loginWithUI()

--- a/cypress/integration/Basic Flows/project.spec.js
+++ b/cypress/integration/Basic Flows/project.spec.js
@@ -1,0 +1,41 @@
+/// <reference types="cypress" />
+
+context('Projects', () => {
+  beforeEach(() => {
+    cy.loginWithUI()
+  })
+
+  it('user can create a new project', () => {
+    let projectTitle = "Fake Title"
+    let projectAcronym = "FT"
+
+    cy.visit(Cypress.env('baseUrl') + '/packages/create')
+
+    // filling out form
+    cy.get('#id_title').type(projectTitle)
+    cy.get('#id_acronym').type(projectAcronym)
+    cy.get('.usa-radio__label').contains('CMS AWS Commercial East-West').click()
+
+    cy.get('.usa-radio__label').contains('Low').click()
+    cy.get('#next-button').click()
+
+    //in the future this will automatically redirect to the correct page
+    // this is a stand in until we update routing
+    cy.visit(Cypress.env('baseUrl') + '/packages')
+    cy.get('.usa-card__heading').should('contains.text', projectTitle)
+    cy.get('.usa-card__heading').should('contains.text', projectAcronym)
+
+  })
+
+  it('user can view project details', () => {
+    let projectTitle = "Fake Title"
+
+    cy.visit(Cypress.env('baseUrl') + '/packages')
+    cy.get('.usa-card').contains(projectTitle).get('a').contains('Manage Components').click()
+
+    // assert important navigation buttons are present
+    cy.get('#project-controls').should('contain.text', 'Review Controls')
+    cy.get('#project-components').should('contain.text', 'Manage Components')
+    cy.get('#project-ssp').should('contain.text', 'Export System Security Plan')
+  })
+})

--- a/cypress/integration/Basic Flows/user_login.spec.js
+++ b/cypress/integration/Basic Flows/user_login.spec.js
@@ -1,0 +1,41 @@
+/// <reference types="cypress" />
+
+context('Signing in', () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env('loginUrl'))
+  })
+
+  it('can enter login credentials through UI', () => {
+    // start a clean session
+    cy.clearCookies
+    cy.clearLocalStorage
+
+    // logging in
+    cy.get('#sign-in-toggle').click()
+    cy.get('#id_login').type(Cypress.env('dev_user').name)
+    cy.get('#id_password').type(Cypress.env('dev_user').password)
+    cy.get('#sign-in-submit').click()
+
+    cy.get('#user-menu-dropdown').should('contains.text', Cypress.env('dev_user').name)
+
+    // signing out
+    cy.get('#user-menu-dropdown').click()
+    cy.get('#nav-logout-btn').click()
+    cy.get('.usa-alert__body').should('contains.text', 'You have signed out.')    
+  })
+
+  // this example can be used in before actions of other files
+  it('csrf token can be used to login without UI', () => {
+    cy.request(Cypress.env('loginUrl'))
+      .its('body')
+      .then((body) => {
+        const $html = Cypress.$(body)
+        const csrf  = $html.find("input[name=csrfmiddlewaretoken]").val()
+
+        cy.devLoginByCSRF(csrf)
+          .then((resp) => {
+            expect(resp.status).to.eq(200)
+          })
+      })
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,19 +7,31 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('loginWithUI', () => {
+  cy.visit(Cypress.env('loginUrl'))
+  cy.get('#sign-in-toggle').click()
+  cy.get('#id_login').type(Cypress.env('dev_user').name)
+  cy.get('#id_password').type(Cypress.env('dev_user').password)
+  cy.get('#sign-in-submit').click()
+
+  cy.get('#user-menu-dropdown').should('contains.text', Cypress.env('dev_user').name)
+})
+
+Cypress.Commands.add('devLoginByCSRF', (csrfToken) => {
+  cy.request({
+    method: 'POST',
+    url: Cypress.env('loginUrl'),
+    failOnStatusCode: false,
+    form: true,
+    followRedirect: true,
+    headers: {
+      Referer: Cypress.env('loginUrl')
+    },
+    body: {
+      username: Cypress.env('dev_user').name,
+      password: Cypress.env('dev_user').password,
+      csrfmiddlewaretoken: csrfToken
+    }
+  })
+})

--- a/install.md
+++ b/install.md
@@ -220,3 +220,13 @@ When GovReady-Q is running, visit http://localhost:8000/ with your web browser.
 ```
 
 Congratulations, you have installed GovReady-Q!
+
+## Running End-to-End Tests
+
+1. Make sure you have the latest `develop` branch pulled down to your local environment
+2. Run `npm install` from the root directory of the project
+3. Make sure that your local Django project is running and that it is accessible through your browser
+4. If you are running your Django Docker container on something other than port 8000, go to the `/cypress.json` file and update the URLs accordingly.
+5. If you already have a local admin user created, add those credentials to the `dev_user` object in `/cypress.json`.
+6. You can now run `npx cypress open` to start the Cypress testing framework
+7. For more information, checkout https://docs.cypress.io/guides/overview/why-cypress.

--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -65,7 +65,7 @@
                 {% endif %}
                 <li role="separator" class="divider"></li>
                 <li><a href="/accounts/password/change/">Change password</a></li>
-                <li><a href="/accounts/logout/">Log Out</a></li>
+                <li><a id="nav-logout-btn" href="/accounts/logout/">Log Out</a></li>
               </ul>
             </li>
           {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@ Welcome to Compliance Automation
       {% if not hide_registration %}
         <ul class="nav nav-tabs" role="tablist">
           <li id="tab-register" role="presentation" {% if request.POST.action|escapejs != 'login' %}class="active"{% endif %}><a href="#register" aria-controls="register" role="tab" data-toggle="tab">Register</a></li>
-          <li id="tab-signin" role="presentation" {% if request.POST.action|escapejs == 'login' %}class="active"{% endif %}><a href="#signin" aria-controls="signin" role="tab" data-toggle="tab">Sign in</a></li>
+          <li id="tab-signin" role="presentation" {% if request.POST.action|escapejs == 'login' %}class="active"{% endif %}><a id="sign-in-toggle" href="#signin" aria-controls="signin" role="tab" data-toggle="tab">Sign in</a></li>
         </ul>
       {% endif %}
 
@@ -32,7 +32,7 @@ Welcome to Compliance Automation
               {% csrf_token %}
               <input type=hidden name=action value=login>
               {% bootstrap_form login_form %}
-              <p><button type="submit" class="usa-button">Sign in &raquo;</button></p>
+              <p><button id="sign-in-submit" type="submit" class="usa-button">Sign in &raquo;</button></p>
             </form>
             <div><a href="/accounts/password/reset">Forgot password?</a></div>
             {% else %}

--- a/templates/project/project-create.html
+++ b/templates/project/project-create.html
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block pagetitle %}
-  <div class="margin-bottom-3">
+  <div id="title-project-create" class="margin-bottom-3">
     Tell us a little about this system
   </div>
 {% endblock %}


### PR DESCRIPTION
This adds the basic framework for using Cypress tests within our app.  Everything that is here should be able to carry over to all of the potential architectures that we've discussed for future iterations.  As of now, this is only set up for testing locally but will be expandable through environment variables for true end-to-end testing in all of our environments.

None of the tests are currently using the `devLoginByCSRF` command but this will be super useful in the future and was difficult to figure out so I left it in.  Once we are running Cypress in all environments with a larger suite of tests, we will only want to assert logging in with the UI once to avoid bogging down the pipeline.  We should be able to use CSRF tokens to quickly fake a login for other tests and maintain speed but I was having trouble with Django's redirect routing and started to feel out of scope at this point.  There is a chance that this will resolve itself when we iterate on our base application.

Many tests needed to be removed due to the work that Amy is doing around the projects model.  Currently, most of flows do not make any sense ask the models are constantly being swapped as a user works through the app.  This caused me to throw in the towel and only keep what will be useful for us in the future.

Please see the the documentation in `install.md` for instructions on how to run tests.  If you find the directions lacking in any way let me know and I will update accordingly.